### PR TITLE
Fix OCR text handling and screenshot capture robustness

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -30,6 +30,7 @@ def restart_game():
     body.send_keys(Keys.RETURN)  # Ou Keys.SPACE se o jogo reiniciar com 'Espaço'
 
 def capture_screen():
+    screenshot = None
     try:
         canvas = driver.find_element(by=By.TAG_NAME, value="canvas")
         screenshot = Image.open(BytesIO(canvas.screenshot_as_png))

--- a/main.py
+++ b/main.py
@@ -10,13 +10,13 @@ def main():
     thread.start()
 
     for text in extract_text_from_image():
-        if "COMEÇAR" or "COMEGAR" or "COMECAR" in text:
+        if ("COMEÇAR" in text) or ("COMEGAR" in text) or ("COMECAR" in text):
             jump()
 
     while True:
         for text in extract_text_from_image():
-            if "A M E" or "M E" in text:
-                restart_game() 
+            if ("A M E" in text) or ("M E" in text):
+                restart_game()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Correct logical conditions in `main.py` so start and restart checks only trigger when the expected text is detected
- Safeguard `capture_screen` in `automation.py` by initializing the screenshot and returning `None` when the canvas element is missing

## Testing
- `python -m py_compile main.py automation.py`


------
https://chatgpt.com/codex/tasks/task_e_6899089877548333adea6c95d3e57038